### PR TITLE
Names of input variables in dimension keys for reporters and partners ar...

### DIFF
--- a/r_modules/trade_reliability/tradeReliability/getComtradeMirroredData.R
+++ b/r_modules/trade_reliability/tradeReliability/getComtradeMirroredData.R
@@ -14,9 +14,9 @@
 getComtradeMirroredData = function(reportingCountries, partnerCountries, items, years){
         dimensions =
             list(Dimension(name = "reportingCountryM49",
-                           keys = as.character(allReportingCountryCode)),
+                           keys = as.character(reportingCountries)),
                  Dimension(name = "partnerCountryM49",
-                           keys = as.character(allPartnerCountryCode)),
+                           keys = as.character(partnerCountries)),
                  Dimension(name = "measuredItemHS",
                            keys = items),
                  Dimension(name = "measuredElementTrade",


### PR DESCRIPTION
...e changed to be in line with function's parameters' names. Before these variables were taken from calling environment, and variables from function's parameters were not used.